### PR TITLE
Improve Document Type Handling and GitHub Image Fetching

### DIFF
--- a/agents/document_loader/data/sources/drive_folders.txt
+++ b/agents/document_loader/data/sources/drive_folders.txt
@@ -4,4 +4,5 @@
 
 
 1d889-YO5VACLBTc_ltdVx-XsF3M_6ULE AI multimodal
+1EFdWleJRX1JLJbGf0FzdX5jUi8VbNpPb Strategy text
 1W-fv4izwdCAqUVOAhPFdlopb0535ByJu9UWT66nJBDY Local multimodal

--- a/agents/document_loader/src/loaders/drive_loader.py
+++ b/agents/document_loader/src/loaders/drive_loader.py
@@ -295,12 +295,12 @@ class DriveLoader(BaseLoader):
                 file_bytes = self._download_file_bytes(item_id, export_mime_type=(None if mime_type == "application/pdf" else "application/pdf") )
                 if file_bytes:
                     content, images = self._extract_text_and_images_from_pdf_bytes(file_bytes)
-            elif process_mime_type == "text/plain" or process_mime_type == "text/csv":
+            elif process_mime_type == "text/plain" or process_mime_type == "text/csv" or process_mime_type == "text/markdown":
                 # Determine if an export is needed for text content
                 text_export_mime = None
                 if mime_type in self.EXPORT_MIMES and self.EXPORT_MIMES[mime_type] == "text/plain": # e.g. GSlides to text
                     text_export_mime = "text/plain"
-                # if mime_type is already text/plain or text/csv, no export is needed (text_export_mime remains None)
+                # if mime_type is already text/plain or text/csv or text/markdown, no export is needed (text_export_mime remains None)
                 
                 file_bytes = self._download_file_bytes(item_id, export_mime_type=text_export_mime)
                 if file_bytes:

--- a/test_chatbot/chatbot_app.py
+++ b/test_chatbot/chatbot_app.py
@@ -666,6 +666,7 @@ def get_user_friendly_document_type(original_mime_type: Optional[str]) -> str:
     if "vnd.google-apps.presentation" in original_mime_type: return "Google Slides"
     if "vnd.google-apps.spreadsheet" in original_mime_type: return "Google Sheet"
     if "pdf" in original_mime_type: return "PDF"
+    if original_mime_type == "text/markdown": return "Markdown File" # Handle Markdown
     if original_mime_type.startswith("text/"): return original_mime_type.split('/')[1].upper() + " File" # e.g. PLAIN File, CSV File
     if original_mime_type.startswith("image/"): return original_mime_type.split('/')[1].upper() + " Image" # e.g. JPEG Image
     # Fallback for other specific types you might add
@@ -810,7 +811,7 @@ async def get_chatbot_response(user_input, history):
         # Don't stop here, proceed to LLM with "No relevant context found."
 
     # Construct prompt for LLM
-    prompt_template = f"""You are a helpful AI assistant for the Roadmapper application.
+    prompt_template = f"""You are a helpful Product Manager assistant for a Google Product Manager.
 Your goal is to answer the user's question based on the provided context.
 Each piece of context will include: Document ID, Title, Source (e.g., Google Drive, GitHub), Type (e.g., Google Doc, PDF), Category, Source URL, and Content.
 


### PR DESCRIPTION
This PR introduces several enhancements to document loading and metadata processing:

**1. Enhanced GitHub Document Processing (`GitHubLoader`):**

*   **MIME Type Detection:** The `GitHubLoader` now guesses the MIME type of files based on their extension (e.g., `.md` -> `text/markdown`) and stores this in the `Document` metadata as `original_mime_type`. This allows for more accurate document type identification downstream.
*   **Improved GitHub Image Fetching:** When downloading images from `github.com` URLs (especially `user-attachments/assets`), an `Authorization: token <TOKEN>` header is now included in the request if a GitHub token is available. This aims to resolve 404 errors for images that require authentication.

**2. Improved Document Type Display (`chatbot_app.py`):**

*   The `get_user_friendly_document_type` function in the chatbot application has been updated to specifically recognize `text/markdown` MIME types and display them as "Markdown File" to the user, providing clearer information about the document source.

**3. Markdown Support for Google Drive (`DriveLoader`):**

*   The `DriveLoader` can now correctly process Markdown files (`text/markdown`) stored in Google Drive. These files will have their content extracted similar to plain text files, resolving previous warnings about unsupported MIME types for `.md` files from Drive.

**Overall Impact:**

These changes lead to more robust document ingestion, more accurate metadata for GitHub-sourced files, and better user-facing descriptions of document types, particularly for Markdown files from both GitHub and Google Drive. Image loading from GitHub asset URLs should also be more reliable.